### PR TITLE
Replacing text references to Emby with Jellyfin, fixing Server.testConnectionSettings function and progress saving/resume/chapters feature

### DIFF
--- a/app/javascript/Gui/GuiPage_Contributors.js
+++ b/app/javascript/Gui/GuiPage_Contributors.js
@@ -1,7 +1,5 @@
 var GuiPage_Contributors = {
-		MainDevs : ["ChessDragon136","cmcg"],
-		ContribDevs : ["Cragjagged","DrWatson","im85288","arcticwaters","SamES"],
-		DonateSupport : ["c0m3r","Cbers","crashkelly","DaN","FrostByte","gbone8106","ginganinja","grimfandango","fc7","shorty1483","paulsalter","fluffykiwi","oleg","MongooseMan","SilentAssassin","gogreenpower","Ultroman","Spaceboy","JeremyG","strugglez"]
+	CoreTeam : ["nvllsvm","joshuaboniface", "JustAMan", "anthonylavado", "Bond-009", "dkanada"]
 }
 
 GuiPage_Contributors.onFocus = function() {
@@ -17,43 +15,19 @@ GuiPage_Contributors.start = function() {
 	
 	document.getElementById("pageContent").innerHTML = "<div class='EpisodesSeriesInfo'>About:</div><div id=ContentAbout style='font-size:1em;' class='guiPage_Settings_Settings'></div>";
 	
-	var htmlToAdd = "Emby for Samsung Smart TVs is a free, opensource community project. A broad range of Smarthub devices are supported due to the generously donated time and efforts of, among others, the following people.<br>";
-	htmlToAdd += "Feedback on this and other Emby products is gratefully received at emby.media/community.<br><br>"
-	htmlToAdd += "<span style='font-size:1.2em;'>Main Developers</span><table><tr class='guiSettingsRow'>";
-	for (var index = 0; index < this.MainDevs.length; index++) {
+	var htmlToAdd = "Jellyfin for Samsung Smart TVs is a free, open source community project. A broad range of Smarthub devices are supported due to the generously donated time and efforts of, among others, the following people.<br>";
+	htmlToAdd += "Feedback on this and other Jellyfin products is gratefully received at https://jellyfin.org/docs/general/getting-help.html.<br><br>"
+	htmlToAdd += "<span style='font-size:1.2em;'>Core Team</span><table><tr class='guiSettingsRow'>";
+	for (var index = 0; index < this.CoreTeam.length; index++) {
 		if (index % 6 == 0) {
 			htmlToAdd += "<tr class='guiSettingsRow'>";
 		}
-		htmlToAdd += "<td class='guiSettingsTD'>" + this.MainDevs[index] + "</td>";
+		htmlToAdd += "<td class='guiSettingsTD'>" + this.CoreTeam[index] + "</td>";
 		if (index+1 % 6 == 0) {
 			htmlToAdd += "</tr>";
 		}
 	}
 	htmlToAdd += "</tr></table><br><br>";
-	htmlToAdd += "<span style='font-size:1.2em;'>Contributing Developers</span><table><tr class='guiSettingsRow'>";
-	for (var index = 0; index < this.ContribDevs.length; index++) {
-		if (index % 6 == 0) {
-			htmlToAdd += "<tr class='guiSettingsRow'>";
-		}
-		htmlToAdd += "<td class='guiSettingsTD'>" + this.ContribDevs[index] + "</td>";
-		if (index+1 % 6 == 0) {
-			htmlToAdd += "</tr>";
-		}
-	}
-	htmlToAdd += "</tr></table><br><br>";
-	htmlToAdd += "<span style='font-size:1.2em;'>Donators, supporters and valued beta testers.</span><table><tr class='guiSettingsRow'>";
-	for (var index = 0; index < this.DonateSupport.length; index++) {
-		if (index % 7 == 0) {
-			htmlToAdd += "<tr class='guiSettingsRow'>";
-		}
-		htmlToAdd += "<td class='guiSettingsTD'>" + this.DonateSupport[index] + "</td>";
-		if (index+1 % 7 == 0) {
-			htmlToAdd += "</tr>";
-		}
-	}
-	
-	document.getElementById("ContentAbout").innerHTML = htmlToAdd + "</tr></table>";
-	
 	//Set Focus for Key Events
 	document.getElementById("GuiPage_Contributors").focus();
 }

--- a/app/javascript/Gui/GuiPage_Music.js
+++ b/app/javascript/Gui/GuiPage_Music.js
@@ -348,7 +348,7 @@ GuiPage_Music.processSelectedItem = function() {
 	}
 	
 	//Genre Instant Mix
-	//http://192.168.1.108:28067/emby/MusicGenres/Anime/InstantMix?UserId=4b4c128121aa642086bb225659a7d471&Fields=MediaSources%2CChapters&Limit=50
+	//http://192.168.1.108:28067/jellyfin/MusicGenres/Anime/InstantMix?UserId=4b4c128121aa642086bb225659a7d471&Fields=MediaSources%2CChapters&Limit=50
 	//Artist Instant Mix
 	//Artist/NameID/InstatnMix?
 }

--- a/app/javascript/Gui/GuiPage_Settings.js
+++ b/app/javascript/Gui/GuiPage_Settings.js
@@ -1068,7 +1068,7 @@ GuiPage_Settings.setOverview = function() {
 		case "SkipMusicAZ":
 			document.getElementById("guiPage_Settings_Overview_Title").innerHTML = "Skip A-Z Page When Entering Music";
 			document.getElementById("guiPage_Settings_Overview_Content").innerHTML = "Go directly to your entire music collection instead of to the A-Z page." +
-					"<br><br>Only set this True if you have a workable combination of the following:<br>&nbsp;<ul style='padding-left:22px'><li>A modest size music collection.</li><li>A reasonably powerful Emby server.</li><li>A little patience.</li></ul>";
+					"<br><br>Only set this True if you have a workable combination of the following:<br>&nbsp;<ul style='padding-left:22px'><li>A modest size music collection.</li><li>A reasonably powerful Jellyfin server.</li><li>A little patience.</li></ul>";
 			break;
 		case "LargerView":	
 			document.getElementById("guiPage_Settings_Overview_Title").innerHTML = "Display Larger View";
@@ -1129,7 +1129,7 @@ GuiPage_Settings.setOverview = function() {
 			break;	
 		case "ModelOverride":
 			document.getElementById("guiPage_Settings_Overview_Title").innerHTML = "Samsung Evolution Kit";
-			document.getElementById("guiPage_Settings_Overview_Content").innerHTML = "If you have purchased a Samsung Evolution Kit to enhance your TV, select the model number to unlock the addition codec support provided.<br><br>Restart the Emby client for the change to take affect.";
+			document.getElementById("guiPage_Settings_Overview_Content").innerHTML = "If you have purchased a Samsung Evolution Kit to enhance your TV, select the model number to unlock the addition codec support provided.<br><br>Restart the Jellyfin client for the change to take affect.";
 			break;	
 		case "Bitrate":
 			document.getElementById("guiPage_Settings_Overview_Title").innerHTML = "Max Bitrate";
@@ -1153,23 +1153,23 @@ GuiPage_Settings.setOverview = function() {
 			break;	
 		case "DefaultAudioLang":
 			document.getElementById("guiPage_Settings_Overview_Title").innerHTML = "Audio Language Preference";
-			document.getElementById("guiPage_Settings_Overview_Content").innerHTML = "Select the preferred audio language.<br><br>If your language is not listed, you will need to change the setting via the web app which has a full list of languages.<br><br>This is a server option and will affect your Emby experience on all clients";
+			document.getElementById("guiPage_Settings_Overview_Content").innerHTML = "Select the preferred audio language.<br><br>If your language is not listed, you will need to change the setting via the web app which has a full list of languages.<br><br>This is a server option and will affect your Jellyfin experience on all clients";
 			break;	
 		case "PlayDefaultAudioTrack":
 			document.getElementById("guiPage_Settings_Overview_Title").innerHTML = "Play default audio track regardless of language";
-			document.getElementById("guiPage_Settings_Overview_Content").innerHTML = "Will play the default audio track even if it doesn't match your language setting.<br><br>This is a server option and will affect your Emby experience on all clients";
+			document.getElementById("guiPage_Settings_Overview_Content").innerHTML = "Will play the default audio track even if it doesn't match your language setting.<br><br>This is a server option and will affect your Jellyfin experience on all clients";
 			break;	
 		case "DefaultSubtitleLang":
 			document.getElementById("guiPage_Settings_Overview_Title").innerHTML = "Subtitle Language Preference";
-			document.getElementById("guiPage_Settings_Overview_Content").innerHTML = "Select the preferred subtitle language.<br><br>If your language is not listed, you will need to change the setting via the web app which has a full list of languages.<br><br>This is a server option and will affect your Emby experience on all clients";
+			document.getElementById("guiPage_Settings_Overview_Content").innerHTML = "Select the preferred subtitle language.<br><br>If your language is not listed, you will need to change the setting via the web app which has a full list of languages.<br><br>This is a server option and will affect your Jellyfin experience on all clients";
 			break;		
 		case "SubtitleMode":
 			document.getElementById("guiPage_Settings_Overview_Title").innerHTML = "Subtitle Mode";
-			document.getElementById("guiPage_Settings_Overview_Content").innerHTML = "Select the default behaviour of when subtitles are loaded<br><br>Default: Subtitles matching the language preference will be loaded when the audio is in a foreign language.<br><br>Only Forced Subtitles: Only subtitles marked as forced will be loaded.<br><br>Always Play Subtitles: Subtitles matching the language preference will be loaded regardless of the audio language.<br><br>None: Subtitles will not be loaded by default.<br><br>This is a server option and will affect your Emby experience on all clients";
+			document.getElementById("guiPage_Settings_Overview_Content").innerHTML = "Select the default behaviour of when subtitles are loaded<br><br>Default: Subtitles matching the language preference will be loaded when the audio is in a foreign language.<br><br>Only Forced Subtitles: Only subtitles marked as forced will be loaded.<br><br>Always Play Subtitles: Subtitles matching the language preference will be loaded regardless of the audio language.<br><br>None: Subtitles will not be loaded by default.<br><br>This is a server option and will affect your Jellyfin experience on all clients";
 			break;	
 		case "HidePlayedInLatest":
 			document.getElementById("guiPage_Settings_Overview_Title").innerHTML = "Hide watched content from latest media";
-			document.getElementById("guiPage_Settings_Overview_Content").innerHTML = "Watched items will not appear in the Latest TV or Latest Movies home views or pages.<br><br>This is a server option and will affect your Emby experience on all clients";
+			document.getElementById("guiPage_Settings_Overview_Content").innerHTML = "Watched items will not appear in the Latest TV or Latest Movies home views or pages.<br><br>This is a server option and will affect your Jellyfin experience on all clients";
 			break;
 		case "EnableCinemaMode":
 			document.getElementById("guiPage_Settings_Overview_Title").innerHTML = "Enable cinema mode";
@@ -1177,15 +1177,15 @@ GuiPage_Settings.setOverview = function() {
 			break;
 		case "DisplayMissingEpisodes":
 			document.getElementById("guiPage_Settings_Overview_Title").innerHTML = "Display Missing Episodes within Seasons";
-			document.getElementById("guiPage_Settings_Overview_Content").innerHTML = "Display missing episodes within TV seasons<br><br>This is a server option and will affect your Emby experience on all clients";
+			document.getElementById("guiPage_Settings_Overview_Content").innerHTML = "Display missing episodes within TV seasons<br><br>This is a server option and will affect your Jellyfin experience on all clients";
 			break;	
 		case "DisplayUnairedEpisodes":
 			document.getElementById("guiPage_Settings_Overview_Title").innerHTML = "Display Unaired Episodes within Seasons";
-			document.getElementById("guiPage_Settings_Overview_Content").innerHTML = "Display unaired episodes within TV seasons<br><br>This is a server option and will affect your Emby experience on all clients";
+			document.getElementById("guiPage_Settings_Overview_Content").innerHTML = "Display unaired episodes within TV seasons<br><br>This is a server option and will affect your Jellyfin experience on all clients";
 			break;	
 		case "GroupMovieCollections":
 			document.getElementById("guiPage_Settings_Overview_Title").innerHTML = "Group Movies into Collections";
-			document.getElementById("guiPage_Settings_Overview_Content").innerHTML = "When displaying movie lists, movies belonging to a collection will be displayed as one grouped item<br><br>This is a server option and will affect your Emby experience on all clients";
+			document.getElementById("guiPage_Settings_Overview_Content").innerHTML = "When displaying movie lists, movies belonging to a collection will be displayed as one grouped item<br><br>This is a server option and will affect your Jellyfin experience on all clients";
 			break;		
 	}
 }

--- a/app/javascript/Gui/GuiPlayer/GuiPlayer.js
+++ b/app/javascript/Gui/GuiPlayer/GuiPlayer.js
@@ -2,7 +2,7 @@
 //
 //Samsung Player accepts seconds
 //Samsung Current time works in seconds * 1000
-//Emby works in seconds * 10000000
+//Jellyfin works in seconds * 10000000
 
 var GuiPlayer = {	
 		plugin : null,

--- a/app/javascript/Gui/GuiPlayer/GuiPlayer.js
+++ b/app/javascript/Gui/GuiPlayer/GuiPlayer.js
@@ -170,9 +170,6 @@ GuiPlayer.startPlayback = function(TranscodeAlg, resumeTicksSamsung) {
 	this.PlaySessionId = playbackInfo ? playbackInfo.PlaySessionId : null;
 
 	var url = this.playingURL + '&PlaySessionId=' + this.PlaySessionId;
-	
-	//Update URL with resumeticks
-	url += '&StartTimeTicks=' + (resumeTicksSamsung*10000);
 
 	//Required for HLS streaming
 	if (this.PlayMethod != "DirectPlay") {
@@ -866,9 +863,6 @@ GuiPlayer.newPlaybackPosition = function(startPositionTicks) {
 	this.setDisplaySize();
 	
 	var url = this.playingURL + '&PlaySessionId=' + this.PlaySessionId;
-	
-	//Update URL with startPositionTicks
-	url += '&StartTimeTicks=' + (Math.round(startPositionTicks));
 
 	//Required for HLS streaming
 	if (this.PlayMethod != "DirectPlay") {

--- a/app/javascript/Main.js
+++ b/app/javascript/Main.js
@@ -88,7 +88,7 @@ Main.onLoad = function()
 	//Setup Logging
 	FileLog.loadFile(false); // doesn't return contents, done to ensure file exists
 	FileLog.write("---------------------------------------------------------------------",true);
-	FileLog.write("Emby Application Started");
+	FileLog.write("Jellyfin Application Started");
 	
 	if (Main.isImageCaching()) {
 		var fileSystemObj = new FileSystem();
@@ -158,67 +158,67 @@ Main.onLoad = function()
 		Server.setDevice ("Samsung " + pluginTV.GetProductCode(0));
 		Server.setDeviceID(NNaviPlugin.GetDUID(MAC));
 		
-	    //Load Settings File - Check if file needs to be deleted due to development
-	    var fileJson = JSON.parse(File.loadFile()); 
-	    var version = File.checkVersion(fileJson);
-	    if (version == "Undefined" ) {
-	    	//Delete Settings file and reload
-	    	File.deleteSettingsFile();
-	    	fileJson = JSON.parse(File.loadFile());
-	    } else if (version != this.version) {
-	    	if (this.forceDeleteSettings == true) {
-	    		//Delete Settings file and reload
-	    		File.deleteSettingsFile();
-		    	fileJson = JSON.parse(File.loadFile());
-	    	} else {
-	    		//Update version in settings file to current version
-	    		fileJson.Version = this.version;
-	    	} 	File.writeAll(fileJson);
-	    }
-	    
-	    //Allow Evo Kit owners to override the model year.
-	    if (fileJson.TV.ModelOverride != "None") {
-	    	switch(fileJson.TV.ModelOverride){
-	    	case "SEK1000":
-	    		this.modelYear = "F";
-	    		break;
-	    	case "SEK2000":
-	    		this.modelYear = "H";
-	    		break;
-	    	case "SEK2500":
-	    		this.modelYear = "H";
-	    		break;
-	    	}
-	    	FileLog.write("Model Year Override: " + this.modelYear);
-	    }
-	    
-	    //Check if Server exists
-	    if (fileJson.Servers.length > 1) {
-	    	//If no default show user Servers page (Can set default on that page)
-	    	var foundDefault = false;
-	    	for (var index = 0; index < fileJson.Servers.length; index++) {
-	    		if (fileJson.Servers[index].Default == true) {
-	    			foundDefault = true;
-	    			FileLog.write("Default server found.");
-	    			File.setServerEntry(index);
-	    			Server.testConnectionSettings(fileJson.Servers[index].Path,true);    				
-	    			break;
-	    		}
-	    	}
-	    	if (foundDefault == false) {
-	    		FileLog.write("Multiple servers defined. Loading the select server page.");
-	    		GuiPage_Servers.start();
-	    	}
-	    } else if (fileJson.Servers.length == 1) {
-	    	//If 1 server auto login with that
-	    	FileLog.write("Emby server name found in settings. Auto-connecting.");
-	    	File.setServerEntry(0);
-	    	Server.testConnectionSettings(fileJson.Servers[0].Path,true);
-	    } else {
-	    	//No Server Defined - Load GuiPage_IP
-	    	FileLog.write("No server defined. Loading the new server page.");
-	    	GuiPage_NewServer.start();
-	    }
+		//Load Settings File - Check if file needs to be deleted due to development
+		var fileJson = JSON.parse(File.loadFile()); 
+		var version = File.checkVersion(fileJson);
+		if (version == "Undefined" ) {
+			//Delete Settings file and reload
+			File.deleteSettingsFile();
+			fileJson = JSON.parse(File.loadFile());
+		} else if (version != this.version) {
+			if (this.forceDeleteSettings == true) {
+				//Delete Settings file and reload
+				File.deleteSettingsFile();
+				fileJson = JSON.parse(File.loadFile());
+			} else {
+				//Update version in settings file to current version
+				fileJson.Version = this.version;
+			} 	File.writeAll(fileJson);
+		}
+
+		//Allow Evo Kit owners to override the model year.
+		if (fileJson.TV.ModelOverride != "None") {
+			switch(fileJson.TV.ModelOverride){
+			case "SEK1000":
+				this.modelYear = "F";
+				break;
+			case "SEK2000":
+				this.modelYear = "H";
+				break;
+			case "SEK2500":
+				this.modelYear = "H";
+				break;
+			}
+			FileLog.write("Model Year Override: " + this.modelYear);
+		}
+
+		//Check if Server exists
+		if (fileJson.Servers.length > 1) {
+			//If no default show user Servers page (Can set default on that page)
+			var foundDefault = false;
+			for (var index = 0; index < fileJson.Servers.length; index++) {
+				if (fileJson.Servers[index].Default == true) {
+					foundDefault = true;
+					FileLog.write("Default server found.");
+					File.setServerEntry(index);
+					Server.testConnectionSettings(fileJson.Servers[index].Path,true);
+					break;
+				}
+			}
+			if (foundDefault == false) {
+				FileLog.write("Multiple servers defined. Loading the select server page.");
+				GuiPage_Servers.start();
+			}
+		} else if (fileJson.Servers.length == 1) {
+			//If 1 server auto login with that
+			FileLog.write("Jellyfin server name found in settings. Auto-connecting.");
+			File.setServerEntry(0);
+			Server.testConnectionSettings(fileJson.Servers[0].Path,true);
+		} else {
+			//No Server Defined - Load GuiPage_IP
+			FileLog.write("No server defined. Loading the new server page.");
+			GuiPage_NewServer.start();
+		}
 	} else {
 		document.getElementById("pageContent").innerHTML = "You have no network connectivity to the TV - Please check the settings on the TV";
 	}

--- a/app/javascript/Server.js
+++ b/app/javascript/Server.js
@@ -504,7 +504,7 @@ Server.DELETE = function(url, item) {
 Server.testConnectionSettings = function (server,fromFile) {	
 	xmlHttp = new XMLHttpRequest();
 	if (xmlHttp) {
-		xmlHttp.open("GET", "http://" + server + "/emby/System/Info/Public?format=json",false);
+		xmlHttp.open("GET", "http://" + server + "/jellyfin/System/Info/Public?format=json",false);
 		xmlHttp.setRequestHeader("Content-Type", 'application/json');
 		xmlHttp.onreadystatechange = function () {
 			GuiNotifications.setNotification("hello","Network Status",true);
@@ -515,7 +515,7 @@ Server.testConnectionSettings = function (server,fromFile) {
 			    		File.saveServerToFile(json.Id,json.ServerName,server); 
 			    	}
 			       	//Set Server.serverAddr!
-			       	Server.setServerAddr("http://" + server + "/emby");
+			       	Server.setServerAddr("http://" + server + "/jellyfin");
 			       	//Check Server Version
 			       	if (ServerVersion.checkServerVersion()) {
 			       		GuiUsers.start(true);

--- a/app/javascript/Server.js
+++ b/app/javascript/Server.js
@@ -330,7 +330,7 @@ Server.videoStarted = function(showId,MediaSourceID,PlayMethod,PlaySessionId) {
 	var url = this.serverAddr + "/Sessions/Playing";
 	xmlHttp = new XMLHttpRequest();
 	if (xmlHttp) {
-		var contentToPost = '{"QueueableMediaTypes":["Video"],"CanSeek":false,"ItemId":'+showId+',"PlaySessionId":'+PlaySessionId+',"MediaSourceId":'+MediaSourceID+',"IsPaused":false,"IsMuted":false,"PositionTicks":0,"PlayMethod":'+PlayMethod+'}';
+		var contentToPost = '{"QueueableMediaTypes":["Video"],"CanSeek":false,"ItemId":"'+showId+'","PlaySessionId":"'+PlaySessionId+'","MediaSourceId":"'+MediaSourceID+'","IsPaused":false,"IsMuted":false,"PositionTicks":0,"PlayMethod":"'+PlayMethod+'"}';
 		xmlHttp.open("POST", url , true); //must be true!
 		xmlHttp = this.setRequestHeaders(xmlHttp);
 		xmlHttp.send(contentToPost);
@@ -341,7 +341,7 @@ Server.videoStopped = function(showId,MediaSourceID,ticks,PlayMethod,PlaySession
 	var url = this.serverAddr + "/Sessions/Playing/Stopped";
 	xmlHttp = new XMLHttpRequest();
 	if (xmlHttp) {
-		var contentToPost = '{"QueueableMediaTypes":["Video"],"CanSeek":false,"ItemId":'+showId+',"PlaySessionId":'+PlaySessionId+',"MediaSourceId":'+MediaSourceID+',"IsPaused":false,"IsMuted":false,"PositionTicks":'+(ticks*10000)+',"PlayMethod":'+PlayMethod+'}';
+		var contentToPost = '{"QueueableMediaTypes":["Video"],"CanSeek":false,"ItemId":"'+showId+'","PlaySessionId":"'+PlaySessionId+'","MediaSourceId":"'+MediaSourceID+'","IsPaused":false,"IsMuted":false,"PositionTicks":'+(ticks*10000)+',"PlayMethod":"'+PlayMethod+'"}';
 		xmlHttp.open("POST", url , true); //must be true!
 		xmlHttp = this.setRequestHeaders(xmlHttp);
 		xmlHttp.send(contentToPost);
@@ -352,7 +352,7 @@ Server.videoPaused = function(showId,MediaSourceID,ticks,PlayMethod,PlaySessionI
 	var url = this.serverAddr + "/Sessions/Playing/Progress";
 	xmlHttp = new XMLHttpRequest();
 	if (xmlHttp) {
-		var contentToPost = '{"QueueableMediaTypes":["Video"],"CanSeek":false,"ItemId":'+showId+',"PlaySessionId":'+PlaySessionId+',"MediaSourceId":'+MediaSourceID+',"IsPaused":true,"IsMuted":false,"PositionTicks":'+(ticks*10000)+',"PlayMethod":'+PlayMethod+'}';
+		var contentToPost = '{"QueueableMediaTypes":["Video"],"CanSeek":false,"ItemId":"'+showId+'","PlaySessionId":"'+PlaySessionId+'","MediaSourceId":"'+MediaSourceID+'","IsPaused":true,"IsMuted":false,"PositionTicks":'+(ticks*10000)+',"PlayMethod":"'+PlayMethod+'"}';
 		xmlHttp.open("POST", url , true); //must be true!
 		xmlHttp = this.setRequestHeaders(xmlHttp);
 		xmlHttp.send(contentToPost);
@@ -363,7 +363,7 @@ Server.videoTime = function(showId,MediaSourceID,ticks,PlayMethod,PlaySessionId)
 	var url = this.serverAddr + "/Sessions/Playing/Progress";
 	xmlHttp = new XMLHttpRequest();
 	if (xmlHttp) {
-		var contentToPost = '{"QueueableMediaTypes":["Video"],"CanSeek":false,"ItemId":'+showId+',"PlaySessionId":'+PlaySessionId+',"MediaSourceId":'+MediaSourceID+',"IsPaused":false,"IsMuted":false,"PositionTicks":'+(ticks*10000)+',"PlayMethod":'+PlayMethod+'}';
+		var contentToPost = '{"QueueableMediaTypes":["Video"],"CanSeek":false,"ItemId":"'+showId+'","PlaySessionId":"'+PlaySessionId+'","MediaSourceId":"'+MediaSourceID+'","IsPaused":false,"IsMuted":false,"PositionTicks":'+(ticks*10000)+',"PlayMethod":"'+PlayMethod+'"}';
 		xmlHttp.open("POST", url , true); //must be true!
 		xmlHttp = this.setRequestHeaders(xmlHttp);
 		xmlHttp.send(contentToPost);
@@ -507,7 +507,7 @@ Server.testConnectionSettings = function (server,fromFile) {
 		xmlHttp.open("GET", "http://" + server + "/jellyfin/System/Info/Public?format=json",false);
 		xmlHttp.setRequestHeader("Content-Type", 'application/json');
 		xmlHttp.onreadystatechange = function () {
-			GuiNotifications.setNotification("hello","Network Status",true);
+			GuiNotifications.setNotification("Connection Test","Network Status",true);
 			if (xmlHttp.readyState == 4) {
 		        if(xmlHttp.status === 200) {
 			    	if (fromFile == false) {

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 	<head>
 		<link href='https://fonts.googleapis.com/css?family=Open+Sans:400,300' rel='stylesheet' type='text/css'>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-		<title>Emby</title>
+		<title>Jellyfin</title>
 
 		<!-- Style sheets -->
 		<link rel="stylesheet" href="Main.css" type="text/css">


### PR DESCRIPTION
Replacing remain text references to "Emby" with "Jellyfin", updating `GuiPage_Contributors.js` with actual Jellyfin core team.
Fixing the `Server.testConnectionSettings` function to be able work with modern Jellyfin implementation since `/emby/System/Info/Public?format=json` path redirects to `/jellyfin/web/index.html` and prevents the app from loading.
Fixing broken progress saving, resume and chapters features due to malformed JSON formatting and unsupported StartTimeTicks parameter in Jellyfin 10.7.x. 